### PR TITLE
48 - Fix Gelly Gun's hands

### DIFF
--- a/lua/autorun/client/gelly-hdr-fix.lua
+++ b/lua/autorun/client/gelly-hdr-fix.lua
@@ -1,0 +1,8 @@
+hook.Add("GellyLoaded", "gelly.fix-hdr-cubemaps", function()
+	local isHDREnabled = GetConVar("mat_hdr_level"):GetInt() >= 2
+	if not isHDREnabled then
+		return
+	end
+
+	gelly.SetCubemapStrength(10)
+end)

--- a/lua/weapons/gelly_gun.lua
+++ b/lua/weapons/gelly_gun.lua
@@ -3,7 +3,7 @@ SWEP.Spawnable = true
 SWEP.AdminOnly = false
 SWEP.PrintName = "Gelly Gun"
 
-SWEP.ViewModel = "models/weapons/v_pistol.mdl"
+SWEP.ViewModel = "models/weapons/c_pistol.mdl"
 SWEP.WorldModel = "models/weapons/w_pistol.mdl"
 SWEP.ViewModelFOV = 54
 SWEP.UseHands = true


### PR DESCRIPTION
Meets the acceptance criteria of #48 by using the correct viewmodel for the Gelly Gun to allow the current playermodel's hands to be used.