### PR TITLE
75 - Fix offset colliders

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -5,5 +5,8 @@
 	],
 	"runtime.special": {
 		"include": "require"
-	}
+	},
+	"diagnostics.disable": [
+		"undefined-global"
+	]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2023-06-12
+
+### Fixed
+
+- Colliders no longer have a 90 degree offset depending on the prop spawned
+
 ## [1.5.0] - 2023-06-11
 
 ### Added

--- a/packages/addon/lua/autorun/client/gelly-object-management.lua
+++ b/packages/addon/lua/autorun/client/gelly-object-management.lua
@@ -14,6 +14,7 @@ local function correctBindPose(bindPose)
 		return bindPose
 	end
 
+	bindPose:SetTranslation(Vector(0, 0, 0))
 	bindPose:SetAngles(Angle(0, 90, 0))
 	return bindPose
 end

--- a/packages/addon/lua/autorun/client/gelly-object-management.lua
+++ b/packages/addon/lua/autorun/client/gelly-object-management.lua
@@ -21,8 +21,7 @@ local function getVerticesOfModel(modelPath)
 	for _, mesh in ipairs(meshes) do
 		local vertsForMesh = {}
 		for _, vertex in ipairs(mesh.triangles) do
-			local newVertexPosition = rootTransform * vertex.pos
-			table.insert(vertsForMesh, newVertexPosition)
+			table.insert(vertsForMesh, rootTransform * vertex.pos)
 		end
 
 		table.insert(vertices, vertsForMesh)

--- a/packages/addon/lua/autorun/client/gelly-object-management.lua
+++ b/packages/addon/lua/autorun/client/gelly-object-management.lua
@@ -6,19 +6,6 @@ local objects = {}
 -- once a multi-mesh object is added.
 local MULTI_OBJECT_OFFSET = 65536
 
-local function correctBindPose(bindPose)
-	local bindAngles = bindPose:GetAngles()
-	local isBad = bindAngles ~= Angle(0, 0, 0)
-
-	if not isBad then
-		return bindPose
-	end
-
-	bindPose:SetTranslation(Vector(0, 0, 0))
-	bindPose:SetAngles(Angle(0, 90, 0))
-	return bindPose
-end
-
 --- Returns a list of the individual meshes and their vertices of the given model.
 ---@param modelPath string
 local function getVerticesOfModel(modelPath)
@@ -28,7 +15,7 @@ local function getVerticesOfModel(modelPath)
 	-- We want to transform the vertices to the root of the model so that there's no visual mismatch
 	local rootTransform = Matrix()
 	if bindPoses then
-		rootTransform = correctBindPose(bindPoses[0].matrix)
+		rootTransform = bindPoses[0].matrix
 	end
 
 	for _, mesh in ipairs(meshes) do
@@ -82,7 +69,7 @@ local function updateObject(entity)
 			return
 		end
 
-		local transform = entity:GetWorldTransformMatrix()
+		local transform = entity:GetBoneMatrix(0)
 		gelly.SetObjectPosition(objectHandle, transform:GetTranslation())
 		gelly.SetObjectRotation(objectHandle, transform:GetAngles())
 	end

--- a/packages/gelly-gmod/src/scene/EntityManager.cpp
+++ b/packages/gelly-gmod/src/scene/EntityManager.cpp
@@ -8,9 +8,8 @@ EntityManager::~EntityManager() {
 	}
 }
 
-std::pair<std::vector<Vector>, std::vector<uint32_t>> EntityManager::ProcessGModMesh(
-	std::vector<Vector> vertices
-) const {
+std::pair<std::vector<Vector>, std::vector<uint32_t>>
+EntityManager::ProcessGModMesh(std::vector<Vector> vertices) const {
 	std::vector<Vector> processedVertices = vertices;
 	std::vector<uint32_t> indices;
 


### PR DESCRIPTION
## Ticket

Resolves #75 

## Changes

- Applies the bind pose for each vertex in any rigid collider (good to know: if there isn't an offset then the bind pose is just an identity matrix)
- Uses `GetBoneMatrix` as the model's transformation instead of `GetWorldTransformMatrix`