### PR TITLE
Tweak the emitter to fix particles spawning too forward

### DIFF
--- a/packages/addon/lua/entities/gelly_disc_emitter.lua
+++ b/packages/addon/lua/entities/gelly_disc_emitter.lua
@@ -21,8 +21,8 @@ function ENT:SetupDataTables()
 end
 
 function ENT:InitializeDefaultSettings()
-	self:SetDensity(355)
-	self:SetSpeed(55)
+	self:SetDensity(200)
+	self:SetSpeed(50)
 	self:SetEnabled(true)
 end
 
@@ -75,9 +75,9 @@ function ENT:Think()
 		local transform = self:GetWorldTransformMatrix()
 
 		gellyx.emitters.Cube({
-			center = Vector(0, 0, 80),
+			center = Vector(0, 0, 3.0 * gellyx.presets.getEffectiveRadius()),
 			velocity = Vector(0, 0, self:GetSpeed()),
-			bounds = Vector(2.3 * gellyx.presets.getEffectiveRadius(), 1.6 * gellyx.presets.getEffectiveRadius(), 80),
+			bounds = Vector(2.0 * gellyx.presets.getEffectiveRadius(), 2.0 * gellyx.presets.getEffectiveRadius(), 3.0 * gellyx.presets.getEffectiveRadius()),
 			density = self:GetDensity(),
 			transform = transform,
 			material = self:IsColorOverrided() and self.PresetMaterial or nil

--- a/packages/addon/lua/entities/gelly_disc_emitter.lua
+++ b/packages/addon/lua/entities/gelly_disc_emitter.lua
@@ -21,7 +21,7 @@ function ENT:SetupDataTables()
 end
 
 function ENT:InitializeDefaultSettings()
-	self:SetDensity(200)
+	self:SetDensity(250)
 	self:SetSpeed(50)
 	self:SetEnabled(true)
 end

--- a/packages/addon/lua/entities/gelly_disc_emitter.lua
+++ b/packages/addon/lua/entities/gelly_disc_emitter.lua
@@ -21,7 +21,7 @@ function ENT:SetupDataTables()
 end
 
 function ENT:InitializeDefaultSettings()
-	self:SetDensity(250)
+	self:SetDensity(200)
 	self:SetSpeed(50)
 	self:SetEnabled(true)
 end


### PR DESCRIPTION
## Ticket

Resolves NONE

## Changes

- Replaced 80 with a size relative to the particle radius
- Tweaked some values because why not

Example of particles spawning too forward. Speed is set to 1.
![gm_g-water0002](https://github.com/user-attachments/assets/2678d83e-e4e7-477d-8e90-c81f397ee4f5)
